### PR TITLE
Bug fixes

### DIFF
--- a/src/commands/dev/dev.rs
+++ b/src/commands/dev/dev.rs
@@ -1,20 +1,6 @@
-use super::super::argparser::ArgParser;
-use super::super::cmds::normalize_path;
 use super::{init_info, lock};
-use crate::metainfo::info_reader::{read_get_obj_info, update_obj_status};
-use crate::metainfo::lock_perm::operation_locked_perm;
-use crate::metainfo::read_lock_perm;
-use crate::rns::security::{argonhash, characterise_enc_key, decrypt, encrypt};
-use crate::utils::{
-    //globals::{USER_NAME, USER_SALT},
-    log,
-    prompt::UserPrompter,
-};
-use argon2::password_hash::SaltString;
-use rocket::http::tls::rustls::internal::msgs::message;
-use serde_json::Value;
+use crate::utils::prompt::UserPrompter;
 use std::path::Path;
-use std::result;
 pub fn dev(
     parts: &[&str],
     current_dir: &Path,
@@ -31,16 +17,16 @@ pub fn dev(
             if msg.is_err() {
                 return msg.err().unwrap();
             }
-            return msg.unwrap();
+            msg.unwrap()
         }
         "info" => {
             let msg = init_info::dev_info(&parts[1..], current_dir, root_dir);
             if msg.is_err() {
                 return msg.err().unwrap();
             }
-            return msg.unwrap();
+            msg.unwrap()
         }
 
-        _ => return "Invalid dev command".to_string(),
+        _ => "Invalid dev command".to_string(),
     }
 }

--- a/src/commands/dev/init_info.rs
+++ b/src/commands/dev/init_info.rs
@@ -1,21 +1,8 @@
 use super::super::argparser::ArgParser;
-use super::super::cmds::normalize_path;
 use crate::metainfo::info_reader::{
-    read_about, read_get_obj_info, read_location, update_obj_status, write_about,
+    read_about, read_location, write_about,
 };
-use crate::metainfo::lock_perm::operation_locked_perm;
-use crate::metainfo::read_lock_perm;
-use crate::rns::security::{argonhash, characterise_enc_key, decrypt, encrypt};
-use crate::utils::{
-    //globals::{USER_NAME, USER_SALT},
-    log,
-    prompt::UserPrompter,
-};
-use argon2::password_hash::SaltString;
-use rocket::http::tls::rustls::internal::msgs::message;
-use serde_json::Value;
 use std::path::Path;
-use std::result;
 pub const HELP_TEXT: &str = r#"
 Usage: dev info [OPTIONS_1] <PROPERTY_NAME> <PROPERTY_VALUE(if writing)> 
 
@@ -85,16 +72,16 @@ pub fn dev_info(args: &[&str], current_dir: &Path, root_dir: &Path) -> Result<St
                 }
                 //join args[2..] to a string
                 property_value = Some(args[2..].join(" "));
-                return write_about(&info_path, property_value.unwrap());
+                write_about(&info_path, property_value.unwrap())
             }
             "-l" | "--location" => {
-                return Err("Cannot write to location field.".to_string());
+                Err("Cannot write to location field.".to_string())
             }
             _ => {
-                return Err("Invalid field. Use -a/--about or -l/--location.".to_string());
+                Err("Invalid field. Use -a/--about or -l/--location.".to_string())
             }
         }
     } else {
-        return Err("Invalid mode. Use -w/--write or -r/--read.".to_string());
+        Err("Invalid mode. Use -w/--write or -r/--read.".to_string())
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,7 +19,6 @@ mod go;
 pub use go::go;
 
 mod copy;
-pub use copy::copy;
 
 mod exit;
 pub use exit::exit;
@@ -31,19 +30,13 @@ mod read;
 pub use read::read;
 
 mod argparser;
-pub use argparser::ArgParser;
 
 mod restore;
-pub use restore::restore;
 
 mod save;
-pub use save::save;
 
 mod solve;
-pub use solve::solve;
 
 mod unlock;
-pub use unlock::unlock;
 
 mod dev;
-pub use dev::dev::dev;

--- a/src/commands/unlock.rs
+++ b/src/commands/unlock.rs
@@ -188,7 +188,7 @@ pub fn unlock(
                             "unlock",
                             "changes regarding lock status of object made to info.json successfully",
                         );
-                        format!("{} is unlocked", locked_obj_name)
+                        format!("{locked_obj_name} is unlocked")
                     } else {
                         //flag incorrect or faced some error
                         err_msg += message.as_str();
@@ -228,7 +228,7 @@ pub fn unlock(
                             "changes regarding lock status of object made to info.json successfully",
                         );
 
-                        format!(" Chest {} is unlocked", locked_obj_name)
+                        format!(" Chest {locked_obj_name} is unlocked")
                     } else {
                         //flag incorrect or faced some error
                         err_msg += message.as_str();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,24 @@
 #![allow(unused_variables, unused_mut, dead_code)]
 // Import everything from the library crate instead of declaring separate modules
+mod commands;
 mod gui_shell;
 mod keys;
 mod login;
+mod menu;
+mod metainfo;
+mod rns;
 mod server;
 mod utils;
-use crate::DEBUG_MODE;
+use std::sync::OnceLock;
+
+pub static DEBUG_MODE: OnceLock<bool> = OnceLock::new();
+pub static SEKAI_DIR: OnceLock<String> = OnceLock::new();
+
 use crate::gui_shell::run_gui_loop;
 use crate::metainfo::valid_sekai::validate_or_create_sekai;
 use crate::rns::restore_comp;
 use crate::utils::globals::set_world_dir;
 use crate::utils::{debug_mode, find_root, log};
-use deemak::*;
 use raylib::ffi::{SetConfigFlags, SetTargetFPS};
 use raylib::prelude::get_monitor_width;
 

--- a/src/metainfo/info_reader.rs
+++ b/src/metainfo/info_reader.rs
@@ -240,7 +240,7 @@ pub fn write_about(info_path: &Path, new_value: String) -> Result<String, String
     info.about = new_value;
     let json = serde_json::to_string_pretty(&info).map_err(|e| e.to_string())?;
     fs::write(info_path, json).map_err(|e| e.to_string())?;
-    return Ok("write successful".to_string());
+    Ok("write successful".to_string())
 }
 
 /// Add an object to info.json with optional initial properties

--- a/src/metainfo/info_reader.rs
+++ b/src/metainfo/info_reader.rs
@@ -180,27 +180,29 @@ pub fn read_validate_info(info_path: &Path) -> Result<Info, InfoError> {
                     obj_info.properties.remove("obj_salt");
                     obj_info.properties.remove("decrypt_me");
                     obj_info.properties.remove("compare_me");
-                }
-                // ensure it has a 'decrypt_me' property
-                if is_level && !obj_info.properties.contains_key("decrypt_me") {
-                    return Err(InfoError::ValidationError(format!(
-                        "Locked objects must have a 'decrypt_me' property. Object Info: {:?}",
-                        obj_info.properties
-                    )));
-                }
-                // obj_salt is required for locked objects
-                if !obj_info.properties.contains_key("obj_salt") {
-                    return Err(InfoError::ValidationError(format!(
-                        "Locked objects must have an 'obj_salt' property. Object Info: {:?}",
-                        obj_info.properties
-                    )));
-                }
-                // enure it has a "compare me property
-                if !obj_info.properties.contains_key("compare_me") {
-                    return Err(InfoError::ValidationError(format!(
-                        "Locked objects must have a 'compare_me' property. Object Info: {:?}",
-                        obj_info.properties
-                    )));
+                } else {
+                    // Only check these properties if the object is actually locked
+                    // ensure it has a 'decrypt_me' property
+                    if is_level && !obj_info.properties.contains_key("decrypt_me") {
+                        return Err(InfoError::ValidationError(format!(
+                            "Locked objects must have a 'decrypt_me' property. Object Info: {:?}",
+                            obj_info.properties
+                        )));
+                    }
+                    // obj_salt is required for locked objects
+                    if !obj_info.properties.contains_key("obj_salt") {
+                        return Err(InfoError::ValidationError(format!(
+                            "Locked objects must have an 'obj_salt' property. Object Info: {:?}",
+                            obj_info.properties
+                        )));
+                    }
+                    // enure it has a "compare me property
+                    if !obj_info.properties.contains_key("compare_me") {
+                        return Err(InfoError::ValidationError(format!(
+                            "Locked objects must have a 'compare_me' property. Object Info: {:?}",
+                            obj_info.properties
+                        )));
+                    }
                 }
             } else {
                 // If not locked, ensure 'decrypt_me' is not present

--- a/src/metainfo/lock_perm.rs
+++ b/src/metainfo/lock_perm.rs
@@ -1,4 +1,4 @@
-use super::info_reader::{read_validate_info, update_obj_status};
+use super::info_reader::read_validate_info;
 use crate::utils::log;
 use crate::utils::relative_deemak_path;
 use std::path::Path;


### PR DESCRIPTION
Changes Made:

**1. `main.rs`**

* Removed `use deemak::*` to avoid trait conflicts.
* Added explicit local module declarations and required `static` variables for better clarity and separation.

**2. `info_reader.rs`**

  * Now checks crypto-related properties **only** for objects explicitly marked as locked.
  * Moved these validation checks inside the else block that only executes when is_locked is true.
  * Objects with `"locked": "00"` bypass cryptographic validation as intended.


Rest are by copilot..